### PR TITLE
Pins Terraform version for greater stability

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -31,7 +31,7 @@ jobs:
       uses: hashicorp/setup-terraform@v1
       with:
         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
-        terraform_version: 1.3.1
+        terraform_version: 1.3.0
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -31,6 +31,7 @@ jobs:
       uses: hashicorp/setup-terraform@v1
       with:
         cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_version: 1.3.1
 
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "=1.3.0"
   backend "remote" {
     # The name of your Terraform Cloud organization.
     organization = "Rod-training"
@@ -9,18 +10,8 @@ terraform {
   }
 }
 
-/* variable "ARM_SUBSCRIPTION_ID" {}
-variable "ARM_CLIENT_ID" {}
-variable "ARM_CLIENT_SECRET" {}
-variable "ARM_TENANT_ID" {} */
-
 provider "azurerm" {
   features {}
-
-  /* subscription_id = var.ARM_SUBSCRIPTION_ID
-  client_id       = var.ARM_CLIENT_ID
-  client_secret   = var.ARM_CLIENT_SECRET
-  tenant_id       = var.ARM_TENANT_ID */
 }
 
 data "azurerm_client_config" "current" {}


### PR DESCRIPTION
Related to issue #1 

- Terraform version pinned to 1.3.0 in workflow
- Terraform version pinned to 1.3.0 in TF provider block
- Terraform workspace set to 1.3.0